### PR TITLE
Add support for 1.14

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -2,3 +2,4 @@ name: Elevators
 main: org.inventivetalent.elevator.Elevators
 author: inventivetalent
 version: ${project.version}
+api-version: 1.13

--- a/src/org/inventivetalent/elevator/ElevatorValidator.java
+++ b/src/org/inventivetalent/elevator/ElevatorValidator.java
@@ -36,7 +36,7 @@ public class ElevatorValidator {
 		for (int i = start; i < end; i++) {
 			Location loc = new Location(elevator.getWorld(), elevator.getX(), i, elevator.getZ());
 			if (loc.getBlock().getType() != Material.AIR) {
-				if (loc.getBlock().getType() == Material.WALL_SIGN) { continue; }
+				if (loc.getBlock().getBlockData() instanceof org.bukkit.block.data.type.WallSign) { continue; }
 				if ((loc.getBlock().getType() == elevator.getMaterial().getItemType() && loc.getBlock().getData() == elevator.getMaterial().getData())) {
 					continue;
 				}

--- a/src/org/inventivetalent/elevator/FloorFinder.java
+++ b/src/org/inventivetalent/elevator/FloorFinder.java
@@ -44,16 +44,16 @@ public class FloorFinder {
 	}
 
 	void checkBlock(Block block) {
-		if (block.getType() != Material.AIR) {
-			if (block.getType() == Material.WALL_SIGN) {
-				Sign currentSign = (Sign) block.getState();
-				Block currentBlock = block.getLocation().add(0, -2, 0).getBlock();
+		if (block.getBlockData() instanceof org.bukkit.block.data.type.WallSign) {
+			Sign currentSign = (Sign) block.getState();
+			Block currentBlock = block.getLocation().add(0, -2, 0).getBlock();
 
-				ParsedSign parsed = ParsedSign.get(currentSign);
+			ParsedSign parsed = ParsedSign.get(currentSign);
 
-				Floor floor = new Floor(currentBlock, parsed);
-				if (!floors.contains(floor)) { floors.add(floor); }
-			} else { count++; }
+			Floor floor = new Floor(currentBlock, parsed);
+			if (!floors.contains(floor)) { floors.add(floor); }
+		} else if (block.getType() != Material.AIR) {
+			count++;
 		} else { count = 0; }
 	}
 

--- a/src/org/inventivetalent/elevator/listener/SignListener.java
+++ b/src/org/inventivetalent/elevator/listener/SignListener.java
@@ -27,7 +27,7 @@ public class SignListener implements Listener {
 		final Block block = event.getClickedBlock();
 		if (block == null) { return; }
 		if (event.getAction() != Action.RIGHT_CLICK_BLOCK) { return; }
-		if (block.getType() == Material.WALL_SIGN) {
+		if (block.getBlockData() instanceof org.bukkit.block.data.type.WallSign) {
 			try {
 				Sign sign = (Sign) block.getState();
 				String[] lines = sign.getLines();
@@ -115,7 +115,7 @@ public class SignListener implements Listener {
 
 	@EventHandler
 	public void onBlockBreak(BlockBreakEvent event) {
-		if (event.getBlock().getType() == Material.WALL_SIGN) {
+		if (event.getBlock().getBlockData() instanceof org.bukkit.block.data.type.WallSign) {
 			ParsedSign.reset(event.getBlock().getLocation());
 		}
 	}


### PR DESCRIPTION
- Added support for 1.14 by using instanceof Wall sign instead of
checking against Material.WALL_SIGN (which doesn't exist in 1.14
anymore).
- Dropped support for 1.12 because that version didn't have the (wall)
sign interface yet (introduced in 1.13).
- Changed order of checkBlock checking as WallSigns are now actually considered as Material.AIR.
- Bumped version number and set API version to 1.13 to make sure it
doesn't get loaded on <1.13.